### PR TITLE
Fix formatting for anchored alternation

### DIFF
--- a/src/talonfmt/__init__.py
+++ b/src/talonfmt/__init__.py
@@ -127,7 +127,12 @@ def talonfmt(
     if safe or (safe is None and __debug__):
         ast_for_formatted = parse(formatted, encoding=encoding, raise_parse_error=True)
         # assert: parsing output results in a similar AST
-        ast.assert_equivalent(ast_for_formatted)
+        try:
+            ast.assert_equivalent(ast_for_formatted)
+        except AssertionError as e:
+            raise AssertionError(
+                f"Formatting {filename or 'input'} changes the parse tree: {e}"
+            ) from None
 
         # assert: formatting twice results in the same output
         assert formatted == render(

--- a/src/talonfmt/formatter.py
+++ b/src/talonfmt/formatter.py
@@ -570,9 +570,32 @@ class TalonFormatter:
 
     @format.register
     def _(self, node: TalonChoice) -> Doc:
-        children = self.format_children(node.children)
+        # group optional start/end anchors with the rule they apply to
+        groups: list[Doc] = []
+        children = list(node.children)
+        i = 0
+        start_anchor = False
+        while i < len(children):
+            child = children[i]
+            if isinstance(child, TalonStartAnchor):
+                start_anchor = True
+                i += 1
+                continue
+            if isinstance(child, TalonEndAnchor):
+                # attach end anchor to previous group if any
+                if groups:
+                    groups[-1] = groups[-1] / "$"
+                i += 1
+                continue
+            doc = self.format(child)
+            if start_anchor:
+                doc = Text("^") / doc
+                start_anchor = False
+            groups.append(doc)
+            i += 1
+
         operator = Space / "|" / Space
-        return operator.join(children)
+        return operator.join(groups)
 
     @format.register
     def _(self, node: TalonEndAnchor) -> Doc:

--- a/tests/data/golden/simple/default/anchored_choice.yml
+++ b/tests/data/golden/simple/default/anchored_choice.yml
@@ -1,0 +1,5 @@
+input: |
+  ^a|b: "test"
+output: |
+  ^a | b:
+      "test"


### PR DESCRIPTION
## Summary
- join anchors with rules when formatting TalonChoice
- show a helpful message when AST check fails
- add golden test for anchored alternation

## Testing
- `pytest tests/test_simple.py::test_simple -k anchored_choice -q`
- `pytest tests/test_script.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6889520070948333bdb8e14885f13b59