### PR TITLE
Fix parse tree assertion for commands

### DIFF
--- a/src/talonfmt/formatter.py
+++ b/src/talonfmt/formatter.py
@@ -128,6 +128,21 @@ def _TalonString_assert_equivalent(self: TalonString, other: Node) -> None:
 setattr(TalonString, "assert_equivalent", _TalonString_assert_equivalent)
 
 
+def _TalonCommandDeclaration_assert_equivalent(
+    self: TalonCommandDeclaration, other: Node
+) -> None:
+    assert isinstance(other, TalonCommandDeclaration)
+    self.left.assert_equivalent(other.left)
+    self.right.assert_equivalent(other.right)
+
+
+setattr(
+    TalonCommandDeclaration,
+    "assert_equivalent",
+    _TalonCommandDeclaration_assert_equivalent,
+)
+
+
 def _TalonParenthesized_assert_equivalent(self: Node, other: Node) -> None:
     assert isinstance(other, Node)
     if isinstance(other, (TalonParenthesizedExpression, TalonParenthesizedRule)):
@@ -626,6 +641,12 @@ class TalonFormatter:
         # group optional start/end anchors with the rule they apply to
         groups: list[Doc] = []
         children = list(node.children)
+        rule_children = [
+            c
+            for c in children
+            if not isinstance(c, (TalonStartAnchor, TalonEndAnchor))
+        ]
+        multiple = len(rule_children) > 1
         i = 0
         start_anchor = False
         while i < len(children):
@@ -640,7 +661,10 @@ class TalonFormatter:
                     groups[-1] = groups[-1] / "$"
                 i += 1
                 continue
-            doc = self.format(child)
+            if isinstance(child, TalonParenthesizedRule) and multiple:
+                doc = self._format_parenthesized_rule(child, allow_shrink=False)
+            else:
+                doc = self.format(child)
             if start_anchor:
                 doc = Text("^") / doc
                 start_anchor = False

--- a/tests/data/golden/simple/default/issue3.yml
+++ b/tests/data/golden/simple/default/issue3.yml
@@ -1,0 +1,6 @@
+input: |
+  ^(foo): "bar"
+output: |
+  ^foo:
+      "bar"
+

--- a/tests/data/golden/simple/default/issue3b.yml
+++ b/tests/data/golden/simple/default/issue3b.yml
@@ -1,0 +1,5 @@
+input: |
+  ^window bring ((others | all) | to front): user.menu_select("Window|Bring All to Front")
+output: |
+  ^window bring ((others | all) | to front):
+      user.menu_select("Window|Bring All to Front")

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -45,3 +45,25 @@ def test_simple_align_fixed32(
         return format_simple_align_fixed32(contents, filename=filename)
 
     assert benchmark(format) == golden.out["output"]
+
+
+@mark.golden_test("data/golden/simple/default/issue3.yml")
+def test_issue3(golden: GoldenTestFixture, benchmark: BenchmarkFixture) -> None:
+    filename = golden_path(golden)
+    contents = golden["input"]
+
+    def format() -> str:
+        return format_simple(contents, filename=filename)
+
+    assert benchmark(format) == golden.out["output"]
+
+
+@mark.golden_test("data/golden/simple/default/issue3b.yml")
+def test_issue3b(golden: GoldenTestFixture, benchmark: BenchmarkFixture) -> None:
+    filename = golden_path(golden)
+    contents = golden["input"]
+
+    def format() -> str:
+        return format_simple(contents, filename=filename)
+
+    assert benchmark(format) == golden.out["output"]


### PR DESCRIPTION
## Summary
- fix `assert_equivalent` on `TalonCommandDeclaration` to compare rule and script
- keep parentheses inside choice expressions when needed
- add regression test covering nested choice parentheses

## Testing
- `pytest tests/test_script.py::test_talonfmt_version -q`
- `pytest tests/test_simple.py::test_issue3 -q`
- `pytest tests/test_simple.py::test_issue3b -q`


------
https://chatgpt.com/codex/tasks/task_e_688a4f5c9670833386d3086adbaf475d